### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: :index
 
   def index
-    # @items = Item.includes(:user).order("id DESC")
+    @items = Item.includes(:user).order("id DESC")
   end
 
   def new

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -140,9 +140,6 @@
               <%# //商品が売れていればsold outを表示しましょう %>
 
             </div>
-<%
-=begin
-%>
             <div class='item-info'>
               <h3 class='item-name'>
                 <%= "#{item.name}" %>
@@ -155,9 +152,6 @@
                 </div>
               </div>
             </div>
-<%
-=end
-%>
             <% end %>
           </li>
         <% end %>


### PR DESCRIPTION
# What
出品された商品をトップページで一覧として表示する機能を実装しました。

# Why
今までに出品された商品を、サイトに訪れたユーザーが容易に閲覧できるようにするため。

<br>

###  商品のデータがない場合は、ダミー商品が表示されている
![items_not_exist](https://gyazo.com/eae63c3396ddbf49ac886bda612d51da.gif)

### 商品のデータがある場合は、商品が一覧で表示されている
![items_exist](https://gyazo.com/62846b9716d0b256a181536d44bcbc2c.gif)
